### PR TITLE
Revert "chore(deps): bump highlight.js from 9.18.1 to 10.4.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@nuxtjs/google-analytics": "^2.4.0",
     "@nuxtjs/markdownit": "^1.2.10",
     "@nuxtjs/pwa": "^3.0.1",
-    "highlight.js": "10.4.1",
+    "highlight.js": "9.18.1",
     "markdown-it-anchor": "^5.3.0",
     "markdown-it-katex": "https://github.com/418sec/markdown-it-katex",
     "markdown-it-table-of-contents": "^0.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5186,10 +5186,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highlight.js@10.4.1:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
-  integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
+highlight.js@9.18.1:
+  version "9.18.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
+  integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
 
 highlight.js@^9.12.0:
   version "9.18.3"


### PR DESCRIPTION
This reverts commit 70ceaece60a27ab6a9796abc28c49a98db9bc0e6.

```
app.b520e6b.js:2 Uncaught TypeError: et.a.registerLanguage is not a function
    at Object.<anonymous> (app.b520e6b.js:2)
    at l (runtime.9cb8add.js:1)
    at Module.<anonymous> (app.b520e6b.js:2)
    at Module.<anonymous> (app.b520e6b.js:2)
    at l (runtime.9cb8add.js:1)
    at Object.<anonymous> (app.b520e6b.js:2)
    at l (runtime.9cb8add.js:1)
    at r (runtime.9cb8add.js:1)
    at Array.t [as push] (runtime.9cb8add.js:1)
    at app.b520e6b.js:2
```