### PR TITLE
Surppress the `mode` option warning

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,7 +5,7 @@ require('dotenv').config();
 const siteTitle = '腐ったコロッケ';
 
 export default {
-  mode: 'universal',
+  ssr: true,
   target: 'static',
   meta: [
     { charset: 'utf-8' },


### PR DESCRIPTION
This PR surpresses the following worning.

```
 WARN  mode option is deprecated. You can safely remove it from nuxt.config
```