### PR TITLE
Surppress tailwind warning

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,6 +27,6 @@ module.exports = {
   variants: {},
   plugins: [],
   purge: {
-    enabled: true
+    layers: ['components', 'layouts', 'pages']
   }
 }


### PR DESCRIPTION
This PR fix the following warning.

```
 WARN  warn - The conservative purge mode will be removed in Tailwind
 WARN  warn - Please switch to the new layers mode instead.
```