### PR TITLE
Use @traptitech/markdown-it-katex instead of original one

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "@nuxtjs/google-analytics": "^2.4.0",
     "@nuxtjs/markdownit": "^1.2.10",
     "@nuxtjs/pwa": "^3.0.1",
+    "@traptitech/markdown-it-katex": "^3.4.3",
     "highlight.js": "10.4.1",
     "markdown-it-anchor": "^5.3.0",
-    "markdown-it-katex": "https://github.com/418sec/markdown-it-katex",
     "markdown-it-table-of-contents": "^0.4.4",
     "nuxt": "2.15.7"
   },

--- a/plugins/markdownit.js
+++ b/plugins/markdownit.js
@@ -1,7 +1,7 @@
 import MarkdownIt from 'markdown-it'
 import markdownItAnchor from 'markdown-it-anchor'
 import markdownItTableOfContents from 'markdown-it-table-of-contents'
-import markdownItKatex from 'markdown-it-katex'
+import markdownItKatex from '@traptitech/markdown-it-katex'
 import '~/node_modules/katex/dist/katex.min.css'
 
 import hljs from 'highlight.js/lib/core'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,6 +1479,13 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@traptitech/markdown-it-katex@^3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@traptitech/markdown-it-katex/-/markdown-it-katex-3.4.3.tgz#23dacbd276ac748409a189550e0ecd764cfde8cf"
+  integrity sha512-ZUG8iapT1xL035NWKYvG8/2AczS40G6JkCf+7Ju5G1aKnCbBIwyuoM+AnwJ+j9WdSGzPRYUG2sNels8a8//uPg==
+  dependencies:
+    katex "^0.13.9"
+
 "@types/fibers@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@types/fibers/-/fibers-3.1.1.tgz#b714d357eebf6aec0bc5d70512e573b89bc84f20"
@@ -5694,12 +5701,12 @@ jsonfile@^6.0.1:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
 
-katex@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/katex/-/katex-0.6.0.tgz#12418e09121c05c92041b6b3b9fb6bab213cb6f3"
-  integrity sha1-EkGOCRIcBckgQbazuftrqyE8tvM=
+katex@^0.13.9:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.13.11.tgz#66138ebf173f25ef130cd3a3ea3ea1d12a3f1362"
+  integrity sha512-yJBHVIgwlAaapzlbvTpVF/ZOs8UkTj/sd46Fl8+qAf2/UiituPYVeapVD8ADZtqyRg/qNWUKt7gJoyYVWLrcXw==
   dependencies:
-    match-at "^0.1.0"
+    commander "^6.0.0"
 
 keygrip@~1.1.0:
   version "1.1.0"
@@ -6093,12 +6100,6 @@ markdown-it-anchor@^5.3.0:
   resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz#d549acd64856a8ecd1bea58365ef385effbac744"
   integrity sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==
 
-"markdown-it-katex@https://github.com/418sec/markdown-it-katex":
-  version "2.0.3"
-  resolved "https://github.com/418sec/markdown-it-katex#405b599f6133a8309ca318c3e074fa38fbc413d2"
-  dependencies:
-    katex "^0.6.0"
-
 markdown-it-table-of-contents@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz#3dc7ce8b8fc17e5981c77cc398d1782319f37fbc"
@@ -6114,11 +6115,6 @@ markdown-it@^8.3.1:
     linkify-it "^2.0.0"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
-
-match-at@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/match-at/-/match-at-0.1.1.tgz#25d040d291777704d5e6556bbb79230ec2de0540"
-  integrity sha512-h4Yd392z9mST+dzc+yjuybOGFNOZjmXIPKWjxBd1Bb23r4SmDOsk2NYCU2BMUBGbSpZqwVsZYNq26QS3xfaT3Q==
 
 md5-hex@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
オリジナルの https://github.com/waylonflinn/markdown-it-katex
はメンテナンスされていない。
代わりにメンテしてくれている東京工業大学デジタル創作同好会traPさんのものをつかう。